### PR TITLE
Fix YAML parsing issue

### DIFF
--- a/dashboards/simple-dashboard-CS7001i-WLW196i.yaml
+++ b/dashboards/simple-dashboard-CS7001i-WLW196i.yaml
@@ -145,9 +145,9 @@ views:
             period: hour
             type: statistics-graph
             entities:
-              - sensor.boiler_nrgsupptotal
+              - entity: sensor.boiler_nrgsupptotal
                 name: Erzeugte thermische Energie
-              - sensor.boiler_nrgconstotal
+              - entity: sensor.boiler_nrgconstotal
                 name: Eingesetzte elektrische Energie
             days_to_show: 1
             stat_types:


### PR DESCRIPTION
Add explicit `entity:` key to avoid YAML parser mixing a bare scalar value with a mapping key