### PR TITLE
Update sensor entities for warm water statistics

### DIFF
--- a/dashboards/simple-dashboard.yaml
+++ b/dashboards/simple-dashboard.yaml
@@ -121,14 +121,14 @@ views:
               - type: horizontal-stack
                 cards:
                   - type: statistic
-                    entity: sensor.boiler_wwmeter
+                    entity: sensor.boiler_dhw_meter
                     period:
                       calendar:
                         period: day
                     stat_type: change
                     name: Energieverbrauch (Warmwasser)
                   - type: statistic
-                    entity: sensor.boiler_nrgww
+                    entity: sensor.boiler_dhw_nrg
                     period:
                       calendar:
                         period: day
@@ -192,10 +192,10 @@ views:
               - type: horizontal-stack
                 cards:
                   - type: entity
-                    entity: sensor.boiler_wwmeter
+                    entity: sensor.boiler_dhw_meter
                     name: Energieverbrauch (Heizen)
                   - type: entity
-                    entity: sensor.boiler_nrgww
+                    entity: sensor.boiler_dhw_nrg
                     name: Energieabgabe (Heizen)
                     icon: mdi:water
                 grid_options:


### PR DESCRIPTION
For my Bosch CS6800i I have different entities.
sensor.boiler_wwmeter is in my system: sensor.boiler_dhw_meter sensor.boiler_nrgww is in my system sensor.boiler_dhw_nrg

I am proposing fixes in two sections for this dashboard for hot water (energy per day, total energy)