### PR TITLE
Remove '(Heizen)' and '(Warmwasser)' from names

### DIFF
--- a/dashboards/simple-dashboard.yaml
+++ b/dashboards/simple-dashboard.yaml
@@ -96,7 +96,7 @@ views:
                       calendar:
                         period: day
                     stat_type: change
-                    name: Energieverbrauch (Heizen)
+                    name: Energieverbrauch
                     icon: mdi:lightning-bolt
                   - type: statistic
                     entity: sensor.boiler_nrgheat
@@ -104,7 +104,7 @@ views:
                       calendar:
                         period: day
                     stat_type: change
-                    name: Energieabgabe (Heizen)
+                    name: Energieabgabe
                     icon: mdi:heat-wave
                 grid_options:
                   columns: 18
@@ -126,14 +126,14 @@ views:
                       calendar:
                         period: day
                     stat_type: change
-                    name: Energieverbrauch (Warmwasser)
+                    name: Energieverbrauch
                   - type: statistic
                     entity: sensor.boiler_nrgww
                     period:
                       calendar:
                         period: day
                     stat_type: change
-                    name: Energieabgabe (Warmwasser)
+                    name: Energieabgabe
                     icon: mdi:water
                 grid_options:
                   columns: 18
@@ -171,11 +171,11 @@ views:
                 cards:
                   - type: entity
                     entity: sensor.boiler_meterheat
-                    name: Energieverbrauch (Heizen)
+                    name: Energieverbrauch
                     icon: mdi:lightning-bolt
                   - type: entity
                     entity: sensor.boiler_nrgheat
-                    name: Energieabgabe (Heizen)
+                    name: Energieabgabe
                     icon: mdi:heat-wave
                 grid_options:
                   columns: 18
@@ -193,10 +193,10 @@ views:
                 cards:
                   - type: entity
                     entity: sensor.boiler_wwmeter
-                    name: Energieverbrauch (Heizen)
+                    name: Energieverbrauch
                   - type: entity
                     entity: sensor.boiler_nrgww
-                    name: Energieabgabe (Heizen)
+                    name: Energieabgabe
                     icon: mdi:water
                 grid_options:
                   columns: 18


### PR DESCRIPTION
The names were a bit long, and the information if it is "Heizen" or "Warmwasser" is already shown in the heading above the chart, so it is duplicate information. It looks cleaner this way I think. - And It was 3x Heizen and 1x Warmwasser, i.e. one of the labels was wrong, anyway (Heizen instead of Warmwasser).